### PR TITLE
Add sitemap generation to Gatsby.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,6 +2,7 @@ const path = require(`path`)
 
 module.exports = {
   plugins: [
+    'gatsby-plugin-sitemap',
     'gatsby-plugin-top-layout',
     'gatsby-plugin-image',
     {
@@ -54,5 +55,6 @@ module.exports = {
     targetJournal: 31,
     title: "The MIDAS Journal",
     copyrightHolder: "Kitware, Inc.",
+    siteUrl: 'https://www.midasjournal.org',
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1311,6 +1311,14 @@
         }
       }
     },
+    "@gatsby-contrib/gatsby-plugin-elasticlunr-search": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@gatsby-contrib/gatsby-plugin-elasticlunr-search/-/gatsby-plugin-elasticlunr-search-3.0.2.tgz",
+      "integrity": "sha512-GQUwjZ6/Q6jFl5Kk1zDtquQewbjX4dsLE8g0/V/aA7s5Mvtc7plCYtvSdarqkJdfC41VC31NubHseDqUkoKeRA==",
+      "requires": {
+        "elasticlunr": "^0.9.5"
+      }
+    },
     "@gatsbyjs/reach-router": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/@gatsbyjs/reach-router/-/reach-router-1.3.6.tgz",
@@ -2123,16 +2131,16 @@
       }
     },
     "@material-ui/core": {
-      "version": "5.0.0-alpha.29",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-5.0.0-alpha.29.tgz",
-      "integrity": "sha512-Fxyz4w+OFy097oUz7Gz2d+9S8UAwxyQowC0wkaUDJ4J+aXx+bLD68E2YlFNHVYJM9FsOZhvjNkN2zfd1+7uevQ==",
+      "version": "5.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-5.0.0-alpha.30.tgz",
+      "integrity": "sha512-g3NSMDz00rtyLHFGKA8x3QXWFVeBzuL6Mm+hrE7AAEXc+WhHMUw4T7yz9YQ0QYrcu9+yAWXktm3Gl8vuD2fp1Q==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@material-ui/styled-engine": "5.0.0-alpha.25",
-        "@material-ui/styles": "5.0.0-alpha.29",
+        "@material-ui/styles": "5.0.0-alpha.30",
         "@material-ui/system": "5.0.0-alpha.29",
         "@material-ui/types": "5.1.7",
-        "@material-ui/unstyled": "5.0.0-alpha.29",
+        "@material-ui/unstyled": "5.0.0-alpha.30",
         "@material-ui/utils": "5.0.0-alpha.29",
         "@popperjs/core": "^2.4.4",
         "@types/react-transition-group": "^4.2.0",
@@ -2192,9 +2200,9 @@
       }
     },
     "@material-ui/styles": {
-      "version": "5.0.0-alpha.29",
-      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-5.0.0-alpha.29.tgz",
-      "integrity": "sha512-DOkN9SYwsfMp/B1KFeHkq9WhNNURw7k/hCoQuRPhnsm1rHY7rUMcEDXetePZEztvxA6WX67QJQRPcwovJ6ji/Q==",
+      "version": "5.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-5.0.0-alpha.30.tgz",
+      "integrity": "sha512-2E8ur6fUtLszgD5hStc7UDAdCTVN6BApq7Nhemzn86LEudIsC+KUMs0nm5pUj4EGRI+3TAFKw6Ma9BIWzpc64w==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@emotion/hash": "^0.8.0",
@@ -2269,9 +2277,9 @@
       "integrity": "sha512-OSpB0gEKZm5h4izTLyipb34PkfazpvusgQMDTmFkSuqcKoChTshfGejEYX6uaZ+4m5xlT5qzihE6eKA+JnjELg=="
     },
     "@material-ui/unstyled": {
-      "version": "5.0.0-alpha.29",
-      "resolved": "https://registry.npmjs.org/@material-ui/unstyled/-/unstyled-5.0.0-alpha.29.tgz",
-      "integrity": "sha512-nhtoQ9FT6H4W9udKXlv5R+7y+xmBcKgUoJip588Pq9mLzNwga5n9LHBSU9a6ADcgXCd8wNHGIqqg+oB1qC/BCw==",
+      "version": "5.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@material-ui/unstyled/-/unstyled-5.0.0-alpha.30.tgz",
+      "integrity": "sha512-eslKNd7WWXA9JN9BLLRUJGU5KZ6dPvbLuUE18lfW/8A9Znvz+FVD9Fuio74izRxq3vEHkZDkS/CyaB4sSB/KeQ==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@material-ui/utils": "5.0.0-alpha.29",
@@ -6391,6 +6399,11 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "elasticlunr": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/elasticlunr/-/elasticlunr-0.9.5.tgz",
+      "integrity": "sha1-ZVQbswnd3Qz5Ty0ciGGyvmUbsNU="
+    },
     "electron-to-chromium": {
       "version": "1.3.707",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.707.tgz",
@@ -8830,6 +8843,25 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
           "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        }
+      }
+    },
+    "gatsby-plugin-sitemap": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-3.2.0.tgz",
+      "integrity": "sha512-UIeOClN5o7eoARmLQY8+ad0hE85cJTCDFvnNMmbJ1SzuAyldgHep2GVDw+YbTnPCkP7rXIZ0aYPFhugPOa/Zqw==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "common-tags": "^1.8.0",
+        "minimatch": "^3.0.4",
+        "pify": "^3.0.0",
+        "sitemap": "^1.13.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         }
       }
     },
@@ -15885,6 +15917,15 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
+    "sitemap": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-1.13.0.tgz",
+      "integrity": "sha1-Vpy+IYAgKSamKiZs094Jyc60P4M=",
+      "requires": {
+        "underscore": "^1.7.0",
+        "url-join": "^1.1.0"
+      }
+    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -17366,6 +17407,11 @@
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
     },
+    "underscore": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.0.tgz",
+      "integrity": "sha512-sCs4H3pCytsb5K7i072FAEC9YlSYFIbosvM0tAKAlpSSUgD7yC1iXSEGdl5XrDKQ1YUB+p/HDzYrSG2H2Vl36g=="
+    },
     "unherit": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
@@ -17712,6 +17758,11 @@
           "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
         }
       }
+    },
+    "url-join": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
+      "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
     },
     "url-loader": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "gatsby-plugin-material-ui": "latest",
     "gatsby-plugin-react-helmet": "latest",
     "gatsby-plugin-sharp": "^3.2.0",
+    "gatsby-plugin-sitemap": "^3.2.0",
     "gatsby-source-filesystem": "latest",
     "gatsby-transformer-json": "latest",
     "gatsby-transformer-sharp": "^3.2.0",


### PR DESCRIPTION
Add in a dummy URL which should be replaced with the real one when
creating the production environment via ``npm run build``

Fixes #34 