### PR TITLE
Fix WebpackError: TypeError: Cannot read properties of null (reading 'join')

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -91,7 +91,7 @@ export default function Index({ data }) {
     const row = { id: publication.publication_id,
       title: publication.title,
       authors: publication.authors.map(a => a.author_fullname).join(", "),
-      keywords: publication.tags.join(", "),
+      keywords: publication.tags ? publication.tags.join(", ") : null,
       thumbnail,
     }
     return row


### PR DESCRIPTION
Add protection against `null` publication.tags.