### PR TITLE
Add abstract to crossref submission

### DIFF
--- a/src/resources/doi_submission_generator.py
+++ b/src/resources/doi_submission_generator.py
@@ -29,6 +29,7 @@ import csv
 import string
 import secrets
 import requests
+import pypandoc # requires pandoc-jats in the system
 
 
 def read_current_dois():
@@ -285,9 +286,23 @@ def build_xml_dictionary(metadata, verbose=False):
             contributors_tag.append(person_name_tag)
         meta_xml["contributors_xml"] = etree.tostring(contributors_tag, encoding='unicode')
 
+    # abstract: at the time of writting has to be jats formatted
+    meta_xml["abstract_xml"] = ''
+    abstract = metadata.get("abstract")
+    if abstract:
+        # Pass the abstract to pandoc using pypandoc, requires pandoc-jats installed
+        #  pandoc -f markdown file_with_abstract.md -s --mathml -t jats -o output.xml
+        abstract_jats = pypandoc.convert_text(source=abstract, to="jats", extra_args=("-C","--mathml", "--wrap=none"), format="markdown")
+        # Remove extra linebreaks from original source (in case of double \n)
+        abstract_jats = abstract_jats.replace("</p>\n", "</p>")
+        # Use namespace jats in p tags
+        abstract_jats = abstract_jats.replace("<p>", "<jats:p>").replace("</p>", "</jats:p>")
+        abstract_jats = "<jats:abstract>" + abstract_jats + "</jats:abstract>"
+        meta_xml["abstract_xml"] = abstract_jats
+
     # publication_date:
     meta_xml["publication_date_xml"] = ''
-    date_submitted = metadata["date_submitted"]
+    date_submitted = metadata.get("date_submitted")
     if date_submitted and date_submitted != "null":
         date_submitted_datetime = dateutil_parse(date_submitted)
         publication_date_xml = E.publication_date()

--- a/src/resources/doi_submission_template.xml
+++ b/src/resources/doi_submission_template.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<doi_batch xmlns="http://www.crossref.org/schema/4.4.2" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.2" xsi:schemaLocation="http://www.crossref.org/schema/4.4.2 http://www.crossref.org/schemas/crossref4.4.2.xsd">
+<doi_batch xmlns="http://www.crossref.org/schema/4.4.2" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.4.2" xsi:schemaLocation="http://www.crossref.org/schema/4.4.2 http://www.crossref.org/schemas/crossref4.4.2.xsd" xmlns:jats="http://www.ncbi.nlm.nih.gov/JATS1"
+xmlns:mml="http://www.w3.org/1998/Math/MathML">
   <head>
     <doi_batch_id>{doi_batch_id}</doi_batch_id>
     <timestamp>{timestamp}</timestamp>
@@ -21,6 +22,7 @@
           <title>{title}</title>
         </titles>
         {contributors_xml}
+        {abstract_xml}
         {publication_date_xml}
         <publisher_item>
           <identifier id_type="doi">{formatted_doi}</identifier>

--- a/src/resources/requirements.txt
+++ b/src/resources/requirements.txt
@@ -1,0 +1,5 @@
+lxml==4.6.3
+pypandoc==1.6.4
+python-dateutil==2.8.2
+requests-oauthlib==1.3.0
+requests==2.26.0


### PR DESCRIPTION
Abstract has to be formatted in jats format. See
https://www.crossref.org/documentation/content-registration/descriptive-metadata/abstracts/
Basically jats allow math formulas in a really complex xml format.

We use pandoc-jats (need to be installed in the system) to read our stored
abstract in metadata.json and transform them to jats. We use a thin wrapper
of pandoc in python: pypandoc, to use it.

Tested with local schema validation, and uploading to test server in
crossref.

Also: Add requirements.txt for python dependencies