### PR TITLE
Split About into Manifesto and JournalTechnology tabs

### DIFF
--- a/src/components/JournalTechnology.js
+++ b/src/components/JournalTechnology.js
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import Typography from '@material-ui/core/Typography';
+import MuiLink from '@material-ui/core/Link';
+
+export default function JournalTechnology() {
+  return (
+    <div>
+      <Typography variant="subtitle2" paragraph={true}>
+        Sustainable open science with the power of Web3 technology!
+      </Typography>
+      <Typography variant="overline" paragraph={true}>
+        The Insight Journal 3 (IJ3) is an innovative undertaking to bring sustainability to reproducible research.
+      </Typography>
+      <Typography variant="body1" paragraph={true}>
+        The <emph>Insight Journal 3 (IJ3)</emph> applies <MuiLink href="https://www.youtube.com/watch?v=l44z35vabvA">Web3</MuiLink> technologies that are based on the principles of <strong>verifiability, decentralization,</strong> and <strong>incentive engineering</strong>. 
+      </Typography>
+    </div>
+  )
+}

--- a/src/components/Manifesto.js
+++ b/src/components/Manifesto.js
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import Typography from '@material-ui/core/Typography';
+
+export default function Manifesto() {
+  return (
+    <div>
+      <Typography variant="subtitle2" paragraph={true}>
+        The Insight Journal and the Scientific Method!
+      </Typography>
+      <Typography variant="overline" paragraph={true}>
+        The Insight Journal seeks to provide a realistic support for the endeavor of scientific research in the domain of medical image processing.
+      </Typography>
+      <Typography variant="body1" paragraph={true}>
+        The main motivation for creating the Journal was the insufficiency of the current publications in this domain. Most of those other publications' main purpose is to support the evaluation of scientific productivty for institutions where researchers are employed and for those institutions that provide research funds.
+      </Typography>
+      <Typography variant="body1" paragraph={true}>
+        The delusional character of the current publishing system is clearly visible in its motto:
+      </Typography>
+      <Typography align="center" color="textSecondary" variant="body1" paragraph={true}>
+        "Publish or Perish!"
+      </Typography>
+      <Typography variant="body1" paragraph={true}>
+        Note that it does not say:
+      </Typography>
+      <Typography align="center" color="textSecondary" variant="body1" paragraph={true}>
+        "Research or Perish!"
+      </Typography>
+      <Typography variant="body1" paragraph={true}>
+        This nuance have resulted in the inversion of roles where researchers do work <strong>"in order to publish it"</strong>, not because that research work has a significant impact on their society. As a consequence, researchers only embark on publisheable activities, which of course does not include any significant depart from the views currently held by the establishment of Experts who serve as reviewers of journals.
+      </Typography>
+    </div>
+  )
+}

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -1,41 +1,32 @@
 import * as React from 'react';
 import Container from '@material-ui/core/Container';
-import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
 import Layout from '../components/Layout';
+import Tab from '@material-ui/core/Tab';
+import TabList from '@material-ui/lab/TabList';
+import TabPanel from '@material-ui/lab/TabPanel';
+import TabContext from '@material-ui/lab/TabContext';
+import Manifesto from '../components/Manifesto.js';
+import JournalTechnology from '../components/JournalTechnology.js';
 
 export default function About() {
+  const [value, setValue] = React.useState('1');
+
+  const handleChange = (event, newValue) => {
+    setValue(newValue);
+  };
   return (
     <Layout>
       <Container maxWidth="md">
         <Box sx={{ my: 4 }}>
-          <Typography variant="h4" component="h1" gutterBottom>
-            About the Insight Journal
-          </Typography>
-          <Typography variant="subtitle2" paragraph={true}>
-            The Insight Journal and the Scientific Method!
-          </Typography>
-          <Typography variant="overline" paragraph={true}>
-            The Insight Journal seeks to provide a realistic support for the endeavor of scientific research in the domain of medical image processing.
-          </Typography>
-          <Typography variant="body1" paragraph={true}>
-            The main motivation for creating the Journal was the insufficiency of the current publications in this domain. Most of those other publications' main purpose is to support the evaluation of scientific productivty for institutions where researchers are employed and for those institutions that provide research funds.
-          </Typography>
-          <Typography variant="body1" paragraph={true}>
-            The delusional character of the current publishing system is clearly visible in its motto:
-          </Typography>
-          <Typography align="center" color="textSecondary" variant="body1" paragraph={true}>
-            "Publish or Perish!"
-          </Typography>
-          <Typography variant="body1" paragraph={true}>
-            Note that it does not say:
-          </Typography>
-          <Typography align="center" color="textSecondary" variant="body1" paragraph={true}>
-            "Research or Perish!"
-          </Typography>
-          <Typography variant="body1" paragraph={true}>
-            This nuance have resulted in the inversion of roles where researchers do work <strong>"in order to publish it"</strong>, not because that research work has a significant impact on their society. As a consequence, researchers only embark on publisheable activities, which of course does not include any significant depart from the views currently held by the establishment of Experts who serve as reviewers of journals.
-          </Typography>
+          <TabContext value={value}>
+            <TabList indicatorColor="primary" textColor="primary" aria-label="about component" onChange={handleChange}>
+              <Tab label="Manifesto" value="1" />
+              <Tab label="Technology" value="2" />
+            </TabList>
+            <TabPanel value="1"><Manifesto /></TabPanel>
+            <TabPanel value="2"><JournalTechnology /></TabPanel>
+          </TabContext>
         </Box>
       </Container>
     </Layout>


### PR DESCRIPTION
Organize content and enable specialization across IJ, VTK Journal and
Midal Journal of the Manifesto while sharing JournalTechnology.
