### PR TITLE
Avoid ordering authors alphabetically when rendering

### DIFF
--- a/src/templates/publication.js
+++ b/src/templates/publication.js
@@ -467,7 +467,6 @@ const Render = ({ data, pageContext }) => {
         ordered_authors.push(author.author_fullname)
       }
     }
-    ordered_authors.sort();
   }
   let submit_inst = "";
   let submit_auth = "";


### PR DESCRIPTION
Use `author_place` from metadata.json.

 The authors are correctly ordered by the [author_sort](https://github.com/InsightSoftwareConsortium/InsightJournal/blob/92c1812d5830ea9d50ad71e8bcb239db2e9c477c/src/templates/publication.js#L128-L136) function, no need to use the `sort()` function (alphabetical) again.


Fix #115