### PR TITLE
Address MuiLink warning for GitHub Issues link

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -5,14 +5,14 @@ import Header from './Header'
 import Copyright from './Copyright';
 import SnackbarContent from '@mui/material/SnackbarContent';
 import Button from '@mui/material/Button';
-import Link from '../components/Link';
+import MuiLink from '@mui/material/Link';
 
 const provideFeedback = (
-  <Link to="https://github.com/InsightSoftwareConsortium/InsightJournal/issues">
+  <MuiLink href="https://github.com/InsightSoftwareConsortium/InsightJournal/issues">
     <Button color="secondary" size="small">
       Provide Feedback
     </Button>
-  </Link>
+  </MuiLink>
 );
 
 const Layout = ({ children }) => {

--- a/src/components/PublicationsTable.js
+++ b/src/components/PublicationsTable.js
@@ -60,7 +60,7 @@ export default function PublicationsTable({ rows }) {
   return (
     <>
       <Box className={classes.publicationTable}>
-        <DataGrid autoHeight={true} rowHeight={100} rows={rows} columns={columns} pageSize={5}/>
+        <DataGrid autoHeight={true} rowHeight={100} rowsPerPageOptions={[5]} rows={rows} columns={columns} pageSize={5}/>
       </Box>
     </>
   );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -142,7 +142,7 @@ export default function Index({ data }) {
 	      <Paper elevation={3}>
                 <Typography variant="h5" component="h2" align="center"><IssuesIcon/>{' '}Issues</Typography>
                   <Box className={classes.issueTable}>
-                    <DataGrid autoHeight={true} headerHeight={38} rowHeight={70} rows={issueRows} columns={issueColumns} pageSize={4}/>
+                    <DataGrid autoHeight={true} rowsPerPageOptions={[4]} headerHeight={38} rowHeight={70} rows={issueRows} columns={issueColumns} pageSize={4}/>
                   </Box>
 	      </Paper>
             </Grid>


### PR DESCRIPTION
Address: index.js:242 External link https://github.com/InsightSoftwareConsortium/InsightJournal/issues was detected in a Link component. Use the Link component only for internal links. See: https://gatsby.dev/internal-links
