### PR TITLE
BUG: Add missing revisions to 228 parabolic morphology article

### DIFF
--- a/data/publications/228/metadata.json
+++ b/data/publications/228/metadata.json
@@ -60,6 +60,72 @@
         "handle": "1926/1370",
         "source_code": null,
         "source_code_git_ref": null
+      },
+      {
+        "article": "bafkreigmpzz6s2jdwp6ewfvosnq262nixnhtreptlv6bztbdnppnzi465m",
+        "citation_list": [
+          {
+            "doi": "10.1007/978-1-4613-0469-2_17",
+            "key": "ref1",
+            "score": 146.36916,
+            "unstructured": "Quadratic structuring functions in mathematical morphology+Mathematical Morphology and its Applications to Image and Signal Processing+3+154+1996+1+R. van den Boomgaard+L.S. Makram-Ebeid+J. Schavemaker"
+          },
+          {
+            "key": "ref2",
+            "score": 25.994806,
+            "unstructured": "The ITK Software Guide+2003+L. Ibanez+W. Schroeder"
+          },
+          {
+            "key": "ref3",
+            "score": 17.668854,
+            "unstructured": "Kitware"
+          },
+          {
+            "doi": "10.1016/s0031-3203(99)00160-0",
+            "key": "ref4",
+            "score": 120.48557,
+            "unstructured": "Image sharpening by morphological filtering+Pattern Recognition+4+6+1+1012+2000+J. Schavemaker+M. Reinders+J. Gerbrands+E. Backer"
+          }
+        ],
+        "dapp": null,
+        "dataset": null,
+        "doi": "10.54294/aq68pt",
+        "handle": "1926/1370",
+        "source_code": null,
+        "source_code_git_ref": null
+      },
+      {
+        "article": "bafkreigmpzz6s2jdwp6ewfvosnq262nixnhtreptlv6bztbdnppnzi465m",
+        "citation_list": [
+          {
+            "doi": "10.1007/978-1-4613-0469-2_17",
+            "key": "ref1",
+            "score": 146.36916,
+            "unstructured": "Quadratic structuring functions in mathematical morphology+Mathematical Morphology and its Applications to Image and Signal Processing+3+154+1996+1+R. van den Boomgaard+L.S. Makram-Ebeid+J. Schavemaker"
+          },
+          {
+            "key": "ref2",
+            "score": 25.994806,
+            "unstructured": "The ITK Software Guide+2003+L. Ibanez+W. Schroeder"
+          },
+          {
+            "key": "ref3",
+            "score": 17.668854,
+            "unstructured": "Kitware"
+          },
+          {
+            "doi": "10.1016/s0031-3203(99)00160-0",
+            "key": "ref4",
+            "score": 120.48557,
+            "unstructured": "Image sharpening by morphological filtering+Pattern Recognition+4+6+1+1012+2000+J. Schavemaker+M. Reinders+J. Gerbrands+E. Backer"
+          }
+        ],
+        "dapp": null,
+        "dataset": null,
+        "doi": "10.54294/aq68pt",
+        "handle": "1926/1370",
+        "source_code": null,
+        "source_code_git_ref": null
       }
     ],
     "source_code_git_repo": "https://github.com/InsightSoftwareConsortium/ITKParabolicMorphology.git",


### PR DESCRIPTION
There are 3 revisions to this article. The first revision did not include a PDF. When visiting the page on the deployed website, the PDF never loads.

Copy the metadata to the two other revisions so the latest revision, Revision 3, loads.