### PR TITLE
Add missing revision descriptions for publication 65

### DIFF
--- a/data/publications/65/metadata.json
+++ b/data/publications/65/metadata.json
@@ -70,6 +70,114 @@
         "handle": "1926/153",
         "source_code": "bafybeidhi2vadcmn6gpm7gjmyfuaswc532zz4jxbemlmgitihty7k6xiji",
         "source_code_git_ref": null
+      },
+      {
+        "article": "bafybeieutr43ygteaum5oghr3tt676t2pfdusdnwvtfcqgzshmbo7dnc6i",
+        "citation_list": [
+          {
+            "key": "ref1",
+            "score": 25.964806,
+            "unstructured": "The ITK Software Guide+2003+L. Ibanez+W. Schroeder"
+          },
+          {
+            "key": "ref2",
+            "score": 41.4497,
+            "unstructured": "Morphological Image Analysis: Principles an Applications+2003+P. Soille"
+          },
+          {
+            "doi": "10.1109/83.217222",
+            "key": "ref3",
+            "score": 93.514595,
+            "unstructured": "Morphological grayscale reconstruction in image analysis: Applications and ef cient algorithms+IEEE Transactions on image processing+2+201+1993+Luc Vincent"
+          }
+        ],
+        "dapp": null,
+        "dataset": null,
+        "doi": "10.54294/hva3gz",
+        "handle": "1926/153",
+        "source_code": "bafybeicxoyhjgzknq4xk3gi2h4a3jziabom4nbi6a2sse6nybgfgy7hona",
+        "source_code_git_ref": null
+      },
+      {
+        "article": "bafybeicm2feb6wzmvyle35wcns2geddhb563ukhkihe2nveqkqpeqedu5m",
+        "citation_list": [
+          {
+            "key": "ref1",
+            "score": 25.964806,
+            "unstructured": "The ITK Software Guide+2003+L. Ibanez+W. Schroeder"
+          },
+          {
+            "key": "ref2",
+            "score": 41.4497,
+            "unstructured": "Morphological Image Analysis: Principles an Applications+2003+P. Soille"
+          },
+          {
+            "doi": "10.1109/83.217222",
+            "key": "ref3",
+            "score": 93.514595,
+            "unstructured": "Morphological grayscale reconstruction in image analysis: Applications and ef cient algorithms+IEEE Transactions on image processing+2+201+1993+Luc Vincent"
+          }
+        ],
+        "dapp": null,
+        "dataset": null,
+        "doi": "10.54294/hva3gz",
+        "handle": "1926/153",
+        "source_code": "bafybeiaf5kdjpp3jfx2vb2isocelewyya3zmklsa5l3ccdpm24logvau5i",
+        "source_code_git_ref": null
+      },
+      {
+        "article": "bafybeicm2feb6wzmvyle35wcns2geddhb563ukhkihe2nveqkqpeqedu5m",
+        "citation_list": [
+          {
+            "key": "ref1",
+            "score": 25.964806,
+            "unstructured": "The ITK Software Guide+2003+L. Ibanez+W. Schroeder"
+          },
+          {
+            "key": "ref2",
+            "score": 41.4497,
+            "unstructured": "Morphological Image Analysis: Principles an Applications+2003+P. Soille"
+          },
+          {
+            "doi": "10.1109/83.217222",
+            "key": "ref3",
+            "score": 93.514595,
+            "unstructured": "Morphological grayscale reconstruction in image analysis: Applications and ef cient algorithms+IEEE Transactions on image processing+2+201+1993+Luc Vincent"
+          }
+        ],
+        "dapp": null,
+        "dataset": null,
+        "doi": "10.54294/hva3gz",
+        "handle": "1926/153",
+        "source_code": "bafybeiasbychng5fhmv3pk3i5h5nksquzvovzmvzcj37g76w3flimt3k6a",
+        "source_code_git_ref": null
+      },
+      {
+        "article": "bafybeihipodijss6jpvhyjuafgo3xmnga5tc3eolvy5sl5qiwulucybyku",
+        "citation_list": [
+          {
+            "key": "ref1",
+            "score": 25.964806,
+            "unstructured": "The ITK Software Guide+2003+L. Ibanez+W. Schroeder"
+          },
+          {
+            "key": "ref2",
+            "score": 41.4497,
+            "unstructured": "Morphological Image Analysis: Principles an Applications+2003+P. Soille"
+          },
+          {
+            "doi": "10.1109/83.217222",
+            "key": "ref3",
+            "score": 93.514595,
+            "unstructured": "Morphological grayscale reconstruction in image analysis: Applications and ef cient algorithms+IEEE Transactions on image processing+2+201+1993+Luc Vincent"
+          }
+        ],
+        "dapp": null,
+        "dataset": null,
+        "doi": "10.54294/hva3gz",
+        "handle": "1926/153",
+        "source_code": "bafybeigkuwpiivoavnlwnx64qokmfp3tfplozdlgf3bgatxut2tegja2we",
+        "source_code_git_ref": null
       }
     ],
     "source_code_git_repo": null,


### PR DESCRIPTION
There was no PDF for revision 1. The revision descriptions are missing for the other revisions. This causes the PDF article to not be found when rendered on the website.

Add missing revision information. Updated CIDs can be found via:

```
ipfs ls /ipfs/bafybeialgmdqikskc56dhy2xrnio2te23xdzqdm77wtqxpxybr3ys5cpli/ij-articles/65
ipfs ls /ipfs/bafybeiftka73skceiiq3w5ujjbwyvtfxsfvjitsbz72jh4ws3qu4xzjw2a/ij-source-code/65/
```