### PR TITLE
chore(deps): bump niivue to 0.64.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@awesome.me/webawesome": "3.0.0-beta.6",
     "@niivue/dicom-loader": "^1.0.0",
     "@niivue/itkwasm-loader": "^1.0.2",
-    "@niivue/niivue": "^0.62.1",
+    "@niivue/niivue": "^0.64.0",
     "astro": "^5.14.5",
     "client-zip": "^2.5.0",
     "fuse.js": "^7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       '@niivue/niivue':
-        specifier: ^0.62.1
-        version: 0.62.1
+        specifier: ^0.64.0
+        version: 0.64.0
       astro:
         specifier: ^5.14.5
         version: 5.14.6(@types/node@24.7.2)(rollup@4.52.5)(typescript@5.9.3)(yaml@2.8.1)
@@ -572,8 +572,8 @@ packages:
   '@niivue/itkwasm-loader@1.0.2':
     resolution: {integrity: sha512-Kp6HZ4d2GyyQDtESiD+IF//AiSlqcuzgdZJSZjwQyxKzCQn6hfy6yQh2jd8de2D7JqrXQQCarSMUehvN7YepkA==}
 
-  '@niivue/niivue@0.62.1':
-    resolution: {integrity: sha512-v/D91ICqROoVp+ByDs3JjzotLzC4nJ44181Gl882AaXR62BNsvT4SaDY7ob37Dgv70AScGWsapqiCkHI7gFFgQ==}
+  '@niivue/niivue@0.64.0':
+    resolution: {integrity: sha512-cj7QTlCHZpFiUjZ8DH0M5SzdvbM2VQAjVgvif7xLaRWraiv2MqWdRYcSvF6+KYA0eN9cNVWkEy01NcW4TT0x+w==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -705,11 +705,6 @@ packages:
   '@rollup/rollup-linux-s390x-gnu@4.52.5':
     resolution: {integrity: sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==}
     cpu: [s390x]
-    os: [linux]
-
-  '@rollup/rollup-linux-x64-gnu@4.52.4':
-    resolution: {integrity: sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==}
-    cpu: [x64]
     os: [linux]
 
   '@rollup/rollup-linux-x64-gnu@4.52.5':
@@ -3654,7 +3649,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@niivue/niivue@0.62.1':
+  '@niivue/niivue@0.64.0':
     dependencies:
       '@lukeed/uuid': 2.0.1
       '@ungap/structured-clone': 1.3.0
@@ -3664,7 +3659,7 @@ snapshots:
       nifti-reader-js: 0.8.0
       zarrita: 0.5.4
     optionalDependencies:
-      '@rollup/rollup-linux-x64-gnu': 4.52.4
+      '@rollup/rollup-linux-x64-gnu': 4.52.5
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -3759,9 +3754,6 @@ snapshots:
     optional: true
 
   '@rollup/rollup-linux-s390x-gnu@4.52.5':
-    optional: true
-
-  '@rollup/rollup-linux-x64-gnu@4.52.4':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.52.5':


### PR DESCRIPTION
Includes fixes for Analyze images.
